### PR TITLE
Mps prototype/contextbar

### DIFF
--- a/modules/alloy/src/main/ts/ephox/alloy/api/Main.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/Main.ts
@@ -21,6 +21,7 @@ import * as LayoutInside from '../positioning/layout/LayoutInside';
 import * as LayoutTypes from '../positioning/layout/LayoutTypes';
 import * as MaxHeight from '../positioning/layout/MaxHeight';
 import * as MaxWidth from '../positioning/layout/MaxWidth';
+import * as PinnedLayout from '../positioning/layout/PinnedLayout';
 import {
   AnchorSpec, HotspotAnchorSpec, Layouts, MakeshiftAnchorSpec, NodeAnchorSpec, SelectionAnchorSpec, SubmenuAnchorSpec
 } from '../positioning/mode/Anchoring';
@@ -248,6 +249,7 @@ export {
   // layout
   Layout,
   LayoutInside,
+  PinnedLayout,
   LayoutTypes,
   Bubble,
   MaxHeight,

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/Layout.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/Layout.ts
@@ -38,7 +38,9 @@ const southeast: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubb
   bubbles.southeast(),
   Direction.southeast(),
   boundsRestriction(anchor, { left: AnchorBoxBounds.LeftEdge, top: AnchorBoxBounds.BottomEdge }),
-  'layout-se');
+  'layout-se',
+  false
+);
 
 const southwest: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => NuSpotInfo(
   westX(anchor, element),
@@ -46,7 +48,8 @@ const southwest: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubb
   bubbles.southwest(),
   Direction.southwest(),
   boundsRestriction(anchor, { right: AnchorBoxBounds.RightEdge, top: AnchorBoxBounds.BottomEdge }),
-  'layout-sw'
+  'layout-sw',
+  false
 );
 
 const northeast: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => NuSpotInfo(
@@ -55,7 +58,8 @@ const northeast: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubb
   bubbles.northeast(),
   Direction.northeast(),
   boundsRestriction(anchor, { left: AnchorBoxBounds.LeftEdge, bottom: AnchorBoxBounds.TopEdge }),
-  'layout-ne'
+  'layout-ne',
+  false
 );
 
 const northwest: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => NuSpotInfo(
@@ -64,7 +68,8 @@ const northwest: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubb
   bubbles.northwest(),
   Direction.northwest(),
   boundsRestriction(anchor, { right: AnchorBoxBounds.RightEdge, bottom: AnchorBoxBounds.TopEdge }),
-  'layout-nw'
+  'layout-nw',
+  false
 );
 
 const north: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => NuSpotInfo(
@@ -73,7 +78,8 @@ const north: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles:
   bubbles.north(),
   Direction.north(),
   boundsRestriction(anchor, { bottom: AnchorBoxBounds.TopEdge }),
-  'layout-n'
+  'layout-n',
+  false
 );
 
 const south: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => NuSpotInfo(
@@ -82,7 +88,8 @@ const south: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles:
   bubbles.south(),
   Direction.south(),
   boundsRestriction(anchor, { top: AnchorBoxBounds.BottomEdge }),
-  'layout-s'
+  'layout-s',
+  false
 );
 
 const east: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => NuSpotInfo(
@@ -91,7 +98,8 @@ const east: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: 
   bubbles.east(),
   Direction.east(),
   boundsRestriction(anchor, { left: AnchorBoxBounds.RightEdge }),
-  'layout-e'
+  'layout-e',
+  false
 );
 
 const west: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => NuSpotInfo(
@@ -100,7 +108,8 @@ const west: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: 
   bubbles.west(),
   Direction.west(),
   boundsRestriction(anchor, { right: AnchorBoxBounds.LeftEdge }),
-  'layout-w'
+  'layout-w',
+  false
 );
 
 const all = (): AnchorLayout[] => [ southeast, southwest, northeast, northwest, south, north, east, west ];

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/LayoutInside.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/LayoutInside.ts
@@ -35,7 +35,8 @@ const southeast: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubb
   bubbles.innerSoutheast(),
   Direction.northwest(),
   boundsRestriction(anchor, { right: AnchorBoxBounds.RightEdge, bottom: AnchorBoxBounds.BottomEdge }),
-  'layout-inner-se'
+  'layout-inner-se',
+  false
 );
 
 // positions element in the bottom left of the anchor
@@ -45,7 +46,8 @@ const southwest: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubb
   bubbles.innerSouthwest(),
   Direction.northeast(),
   boundsRestriction(anchor, { left: AnchorBoxBounds.LeftEdge, bottom: AnchorBoxBounds.BottomEdge }),
-  'layout-inner-sw'
+  'layout-inner-sw',
+  false
 );
 
 // positions element in the top right of the anchor
@@ -55,7 +57,8 @@ const northeast: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubb
   bubbles.innerNortheast(),
   Direction.southwest(),
   boundsRestriction(anchor, { right: AnchorBoxBounds.RightEdge, top: AnchorBoxBounds.TopEdge }),
-  'layout-inner-ne'
+  'layout-inner-ne',
+  false
 );
 
 // positions element in the top left of the anchor
@@ -65,7 +68,8 @@ const northwest: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubb
   bubbles.innerNorthwest(),
   Direction.southeast(),
   boundsRestriction(anchor, { left: AnchorBoxBounds.LeftEdge, top: AnchorBoxBounds.TopEdge }),
-  'layout-inner-nw'
+  'layout-inner-nw',
+  false
 );
 
 // positions element at the top of the anchor, horizontally centered
@@ -75,7 +79,9 @@ const north: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles:
   bubbles.innerNorth(),
   Direction.south(),
   boundsRestriction(anchor, { top: AnchorBoxBounds.TopEdge }),
-  'layout-inner-n');
+  'layout-inner-n',
+  false
+);
 
 // positions element at the bottom of the anchor, horizontally centered
 const south: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => NuSpotInfo(
@@ -84,7 +90,8 @@ const south: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles:
   bubbles.innerSouth(),
   Direction.north(),
   boundsRestriction(anchor, { bottom: AnchorBoxBounds.BottomEdge }),
-  'layout-inner-s'
+  'layout-inner-s',
+  false
 );
 
 // positions element with right edge against the anchor, vertically centered
@@ -94,7 +101,9 @@ const east: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: 
   bubbles.innerEast(),
   Direction.west(),
   boundsRestriction(anchor, { right: AnchorBoxBounds.RightEdge }),
-  'layout-inner-e');
+  'layout-inner-e',
+  false
+);
 
 // positions element with left each against the anchor, vertically centered
 const west: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: Bubble) => NuSpotInfo(
@@ -103,7 +112,8 @@ const west: AnchorLayout = (anchor: AnchorBox, element: AnchorElement, bubbles: 
   bubbles.innerWest(),
   Direction.east(),
   boundsRestriction(anchor, { left: AnchorBoxBounds.LeftEdge }),
-  'layout-inner-w'
+  'layout-inner-w',
+  false
 );
 
 const all = (): AnchorLayout[] => [ southeast, southwest, northeast, northwest, south, north, east, west ];

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/LinkedLayout.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/LinkedLayout.ts
@@ -27,7 +27,9 @@ const southeast: AnchorLayout = (anchor, element, bubbles) => NuSpotInfo(
   bubbles.southeast(),
   Direction.southeast(),
   boundsRestriction(anchor, { left: AnchorBoxBounds.RightEdge, top: AnchorBoxBounds.TopEdge }),
-  'link-layout-se');
+  'link-layout-se',
+  true
+);
 
 const southwest: AnchorLayout = (anchor, element, bubbles) => NuSpotInfo(
   westX(anchor, element),
@@ -35,7 +37,9 @@ const southwest: AnchorLayout = (anchor, element, bubbles) => NuSpotInfo(
   bubbles.southwest(),
   Direction.southwest(),
   boundsRestriction(anchor, { right: AnchorBoxBounds.LeftEdge, top: AnchorBoxBounds.TopEdge }),
-  'link-layout-sw'
+  'link-layout-sw',
+  true
+
 );
 
 const northeast: AnchorLayout = (anchor, element, bubbles) => NuSpotInfo(
@@ -44,7 +48,9 @@ const northeast: AnchorLayout = (anchor, element, bubbles) => NuSpotInfo(
   bubbles.northeast(),
   Direction.northeast(),
   boundsRestriction(anchor, { left: AnchorBoxBounds.RightEdge, bottom: AnchorBoxBounds.BottomEdge }),
-  'link-layout-ne'
+  'link-layout-ne',
+  true
+
 );
 
 const northwest: AnchorLayout = (anchor, element, bubbles) => NuSpotInfo(
@@ -53,7 +59,9 @@ const northwest: AnchorLayout = (anchor, element, bubbles) => NuSpotInfo(
   bubbles.northwest(),
   Direction.northwest(),
   boundsRestriction(anchor, { right: AnchorBoxBounds.LeftEdge, bottom: AnchorBoxBounds.BottomEdge }),
-  'link-layout-nw'
+  'link-layout-nw',
+  true
+
 );
 
 const all = (): AnchorLayout[] => [ southeast, southwest, northeast, northwest ];

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/PinnedLayout.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/PinnedLayout.ts
@@ -1,0 +1,41 @@
+import { nu as NuSpotInfo } from '../view/SpotInfo';
+import { Bubble } from './Bubble';
+import * as Direction from './Direction';
+import { boundsRestriction } from './LayoutBounds';
+import { AnchorBox, AnchorElement, AnchorLayout } from './LayoutTypes';
+
+const pinAtTop: AnchorLayout = (
+  anchor: AnchorBox,
+  element: AnchorElement,
+  bubbles: Bubble
+) => {
+  return NuSpotInfo(
+    // cap the bounds.
+    anchor.x + anchor.width / 2 - element.width / 2,
+    anchor.y - element.height,
+    bubbles.north(),
+    Direction.north(),
+    boundsRestriction(anchor, {}),
+    'north-docked',
+    true
+  );
+};
+
+const pinAtBottom: AnchorLayout = (
+  anchor: AnchorBox,
+  element: AnchorElement,
+  bubbles: Bubble
+) => {
+  return NuSpotInfo(
+    // cap the bounds.
+    anchor.x + anchor.width / 2 - element.width / 2,
+    anchor.y + anchor.height,
+    bubbles.south(),
+    Direction.south(),
+    boundsRestriction(anchor, {}),
+    'south-docked',
+    true
+  );
+};
+
+export { pinAtTop, pinAtBottom };

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/ContentAnchorCommon.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/ContentAnchorCommon.ts
@@ -9,19 +9,9 @@ import * as Origins from '../layout/Origins';
 import { Anchoring, NodeAnchor, nu as NuAnchor, SelectionAnchor } from './Anchoring';
 import * as AnchorLayouts from './AnchorLayouts';
 
-const capRect = (left: number, top: number, width: number, height: number): Optional<Boxes.BoxByPoint> => {
-  let newLeft = left, newTop = top, newWidth = width, newHeight = height;
-  // Try to prevent the context toolbar from getting above the editor toolbar
-  if (left < 0) {
-    newLeft = 0;
-    newWidth = width + left;
-  }
-  if (top < 0) {
-    newTop = 0;
-    newHeight = height + top;
-  }
-  const point = CssPosition.screen(SugarPosition(newLeft, newTop));
-  return Optional.some(Boxes.pointed(point, newWidth, newHeight));
+const getBox = (left: number, top: number, width: number, height: number): Optional<Boxes.BoxByPoint> => {
+  const point = CssPosition.screen(SugarPosition(left, top));
+  return Optional.some(Boxes.pointed(point, width, height));
 };
 
 const calcNewAnchor = (optBox: Optional<Boxes.BoxByPoint>, rootPoint: CssPosition.CssPositionAdt, anchorInfo: SelectionAnchor | NodeAnchor, origin: Origins.OriginAdt, elem: SugarElement): Optional<Anchoring> =>
@@ -68,6 +58,6 @@ const calcNewAnchor = (optBox: Optional<Boxes.BoxByPoint>, rootPoint: CssPositio
   });
 
 export {
-  capRect,
+  getBox,
   calcNewAnchor
 };

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/NodeAnchor.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/NodeAnchor.ts
@@ -18,7 +18,7 @@ const placement = (component: AlloyComponent, anchorInfo: NodeAnchor, origin: Or
     .filter(SugarBody.inBody)
     .bind((target) => {
       const rect = target.dom.getBoundingClientRect();
-      const nodeBox = ContentAnchorCommon.capRect(rect.left, rect.top, rect.width, rect.height);
+      const nodeBox = ContentAnchorCommon.getBox(rect.left, rect.top, rect.width, rect.height);
       const elem = anchorInfo.node.getOr(component.element);
       return ContentAnchorCommon.calcNewAnchor(nodeBox, rootPoint, anchorInfo, origin, elem);
     });

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/SelectionAnchor.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/SelectionAnchor.ts
@@ -41,7 +41,7 @@ const placement = (component: AlloyComponent, anchorInfo: SelectionAnchor, origi
         return rect;
       });
     });
-    return optRect.bind((rawRect) => ContentAnchorCommon.capRect(rawRect.left, rawRect.top, rawRect.width, rawRect.height));
+    return optRect.bind((rawRect) => ContentAnchorCommon.getBox(rawRect.left, rawRect.top, rawRect.width, rawRect.height));
   });
 
   const targetElement: Optional<SugarElement> = getAnchorSelection(win, anchorInfo)

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/view/Bounder.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/view/Bounder.ts
@@ -150,7 +150,7 @@ const attempt = (candidate: SpotInfo, width: number, height: number, bounds: Box
 
   // Take special note that we don't use the futz values in the nofit case; whether this position is a good fit is separate
   // to ensuring that if we choose it the popup is actually on screen properly.
-  return originInBounds && sizeInBounds ? adt.fit(reposition) : adt.nofit(reposition, deltaW, deltaH);
+  return (originInBounds && sizeInBounds) || candidate.fitAnyway ? adt.fit(reposition) : adt.nofit(reposition, deltaW, deltaH);
 };
 
 /**

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/view/PositionCss.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/view/PositionCss.ts
@@ -26,6 +26,19 @@ const NuPositionCss = (
 const applyPositionCss = (element: SugarElement, position: PositionCss): void => {
   const addPx = (num: number) => num + 'px';
 
+  /*
+   * Approach
+   *
+   * - if our current styles have a 'top', and we are moving to a bottom, then firstly convert
+   * our top value to a bottom value. Then, reflow. This should allow the transition to animate from
+   * a CSS top to a CSS bottom
+   *
+   * NOTE: You'll need code for finding the equivalent bottom from a top and vice versa. It isn't as
+   * simple as just adding and subtracting element heights. You might need to know the offset parent.
+   *
+   * TODO: Implement ....
+   */
+
   Css.setOptions(element, {
     position: Optional.some(position.position),
     left: position.left.map(addPx),

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/view/SpotInfo.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/view/SpotInfo.ts
@@ -9,6 +9,7 @@ export interface SpotInfo {
   readonly direction: DirectionAdt;
   readonly label: string;
   readonly boundsRestriction: BoundsRestriction;
+  readonly fitAnyway: boolean;
 }
 
 const nu = (
@@ -17,14 +18,16 @@ const nu = (
   bubble: BubbleInstance,
   direction: DirectionAdt,
   boundsRestriction: BoundsRestriction,
-  label: string
+  label: string,
+  fitAnyway: boolean
 ): SpotInfo => ({
   x,
   y,
   bubble,
   direction,
   boundsRestriction,
-  label
+  label,
+  fitAnyway
 });
 
 export {

--- a/modules/tinymce/src/themes/silver/demo/html/demo/demo.html
+++ b/modules/tinymce/src/themes/silver/demo/html/demo/demo.html
@@ -4,6 +4,11 @@
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, maximum-scale=1.0">
   <title>silver-theme Demo Page</title>
+  <style>
+    .tox-pop {
+      transition: all 0.1s ease;
+    }
+  </style>
 </head>
 
 <body style="">

--- a/modules/tinymce/src/themes/silver/demo/html/demo/demo.html
+++ b/modules/tinymce/src/themes/silver/demo/html/demo/demo.html
@@ -1,114 +1,591 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
-<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, maximum-scale=1.0">
-<title>silver-theme Demo Page</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, maximum-scale=1.0">
+  <title>silver-theme Demo Page</title>
 </head>
+
 <body style="">
-<h2>silver-theme Demo Page</h2>
-<div id='tiny-fixed-container' style="border: 10px solid red"></div>
-<div class='tiny-text'>
+  <h2>silver-theme Demo Page</h2>
+  <div id='tiny-fixed-container' style="border: 10px solid red"></div>
+  <div class='tiny-text'>
 
-<p><img src= "/src/plugins/imagetools/demo/img/dogleft.jpg" width="160" height="100"></p>
+    <p><img src="/src/plugins/imagetools/demo/img/dogleft.jpg" width="160" height="100"></p>
 
-<p><a href="http://www.baconipsum.com">Bacon</a> eatsum dolor amet <a href="http://www.baconipsum.com">Bacon</a> sausage bresaola salami porchetta short ribs andouille cow ribeye rump meatball sirloin ham pancetta pork belly. Sausage hamburger beef ribs sirloin, turducken filet mignon fatback shank biltong cow landjaeger. Drumstick pastrami tail venison cow kevin sirloin picanha porchetta short loin hamburger. Shoulder chicken prosciutto turkey pork belly drumstick doner hamburger. Cow tail alcatra pork loin biltong pancetta. Cow cupim tri-tip pancetta brisket hamburger ham, ball tip kielbasa capicola. Pancetta alcatra capicola pork.</p>
-<blockquote><p><a href="http://www.baconipsum.com">Bacon</a> eatsum dolor amet <a href="http://www.baconipsum.com">Bacon</a> sausage bresaola salami porchetta short ribs andouille cow ribeye rump meatball sirloin ham pancetta pork belly. Sausage hamburger beef ribs sirloin, turducken filet mignon fatback shank biltong cow landjaeger. Drumstick pastrami tail venison cow kevin sirloin picanha porchetta short loin hamburger. Shoulder chicken prosciutto turkey pork belly drumstick doner hamburger. Cow tail alcatra pork loin biltong pancetta. Cow cupim tri-tip pancetta brisket hamburger ham, ball tip kielbasa capicola. Pancetta alcatra capicola pork.</p></blockquote>
-<table style="width: 100%">
-<tbody>
-<tr>
-<th colspan="2"><h1><u><a href="http://www.baconipsum.com">Bacon</a> eatsum</u>&sup1;</h1></th>
-</tr>
-<tr>
-<td><h3>Krispy Bacon&#8482;</h3></td><td><h3>Bacon Krispies<small>&reg;</small></h3></td>
-</tr>
-</tbody>
-</table>
-<p>Bacon eatsum dolor amet bacon sausage bresaola salami porchetta short ribs andouille cow ribeye rump meatball sirloin ham pancetta pork belly. Sausage hamburger beef ribs sirloin, turducken filet mignon fatback shank biltong cow landjaeger. Drumstick pastrami tail venison cow kevin sirloin picanha porchetta short loin hamburger. Shoulder chicken prosciutto turkey pork belly drumstick doner hamburger. Cow tail alcatra pork loin biltong pancetta. Cow cupim tri-tip pancetta brisket hamburger ham, ball tip kielbasa capicola. Pancetta alcatra capicola pork.</p>
-<table style="width: 100%">
-<tbody>
-  <tr><th><br/></th><th><br/></th></tr>
-  <tr><td><br/></td><td><br/></td></tr>
-  <tr><td><br/></td><td><br/></td></tr>
-</tbody>
-</table>
-<p>Bacon eatsum dolor amet bacon sausage bresaola salami porchetta short ribs andouille cow ribeye rump meatball sirloin ham pancetta pork belly. Sausage hamburger beef ribs sirloin, turducken filet mignon fatback shank biltong cow landjaeger. Drumstick pastrami tail venison cow kevin sirloin picanha porchetta short loin hamburger. Shoulder chicken prosciutto turkey pork belly drumstick doner hamburger. Cow tail alcatra pork loin biltong pancetta. Cow cupim tri-tip pancetta brisket hamburger ham, ball tip kielbasa capicola. Pancetta alcatra capicola pork.</p>
-<ul>
-<li>
-<h1><u>Bacon eatsum</u>&sup1;</h1>
-<ol>
-<li><h3>Krispy Bacon&#8482;</h3></li>
-<li><h3>Bacon Krispies<small>&reg;</small></h3></li>
-</ol>
-</li>
-</ul>
-<p>Bacon eatsum dolor amet bacon sausage bresaola salami porchetta short ribs andouille cow ribeye rump meatball sirloin ham pancetta pork belly. Sausage hamburger beef ribs sirloin, turducken filet mignon fatback shank biltong cow landjaeger. Drumstick pastrami tail venison cow kevin sirloin picanha porchetta short loin hamburger. Shoulder chicken prosciutto turkey pork belly drumstick doner hamburger. Cow tail alcatra pork loin biltong pancetta. Cow cupim tri-tip pancetta brisket hamburger ham, ball tip kielbasa capicola. Pancetta alcatra capicola pork.</p>
-<p><br/></p>
+    <p><a href="http://www.baconipsum.com">Bacon</a> eatsum dolor amet <a href="http://www.baconipsum.com">Bacon</a>
+      sausage bresaola salami porchetta short ribs andouille cow ribeye rump meatball sirloin ham pancetta pork belly.
+      Sausage hamburger beef ribs sirloin, turducken filet mignon fatback shank biltong cow landjaeger. Drumstick
+      pastrami tail venison cow kevin sirloin picanha porchetta short loin hamburger. Shoulder chicken prosciutto turkey
+      pork belly drumstick doner hamburger. Cow tail alcatra pork loin biltong pancetta. Cow cupim tri-tip pancetta
+      brisket hamburger ham, ball tip kielbasa capicola. Pancetta alcatra capicola pork.</p>
+    <blockquote>
+      <p><a href="http://www.baconipsum.com">Bacon</a> eatsum dolor amet <a href="http://www.baconipsum.com">Bacon</a>
+        sausage bresaola salami porchetta short ribs andouille cow ribeye rump meatball sirloin ham pancetta pork belly.
+        Sausage hamburger beef ribs sirloin, turducken filet mignon fatback shank biltong cow landjaeger. Drumstick
+        pastrami tail venison cow kevin sirloin picanha porchetta short loin hamburger. Shoulder chicken prosciutto
+        turkey pork belly drumstick doner hamburger. Cow tail alcatra pork loin biltong pancetta. Cow cupim tri-tip
+        pancetta brisket hamburger ham, ball tip kielbasa capicola. Pancetta alcatra capicola pork.</p>
+    </blockquote>
+    <table style="width: 100%;">
+      <tbody>
+        <tr>
+          <th colspan="2">
+            <h1><u><a href="http://www.baconipsum.com">Bacon</a> eatsum</u>&sup1;</h1>
+          </th>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
 
-<h3>2nd Iteration</h3>
 
-<p><a href="http://www.baconipsum.com">Bacon</a> eatsum dolor amet <a href="http://www.baconipsum.com">Bacon</a> sausage bresaola salami porchetta short ribs andouille cow ribeye rump meatball sirloin ham pancetta pork belly. Sausage hamburger beef ribs sirloin, turducken filet mignon fatback shank biltong cow landjaeger. Drumstick pastrami tail venison cow kevin sirloin picanha porchetta short loin hamburger. Shoulder chicken prosciutto turkey pork belly drumstick doner hamburger. Cow tail alcatra pork loin biltong pancetta. Cow cupim tri-tip pancetta brisket hamburger ham, ball tip kielbasa capicola. Pancetta alcatra capicola pork.</p>
-<blockquote><p><a href="http://www.baconipsum.com">Bacon</a> eatsum dolor amet <a href="http://www.baconipsum.com">Bacon</a> sausage bresaola salami porchetta short ribs andouille cow ribeye rump meatball sirloin ham pancetta pork belly. Sausage hamburger beef ribs sirloin, turducken filet mignon fatback shank biltong cow landjaeger. Drumstick pastrami tail venison cow kevin sirloin picanha porchetta short loin hamburger. Shoulder chicken prosciutto turkey pork belly drumstick doner hamburger. Cow tail alcatra pork loin biltong pancetta. Cow cupim tri-tip pancetta brisket hamburger ham, ball tip kielbasa capicola. Pancetta alcatra capicola pork.</p></blockquote>
-<table style="width: 100%">
-<tbody>
-<tr>
-<th colspan="2"><h1><u><a href="http://www.baconipsum.com">Bacon</a> eatsum</u>&sup1;</h1></th>
-</tr>
-<tr>
-<td><h3>Krispy Bacon&#8482;</h3></td><td><h3>Bacon Krispies<small>&reg;</small></h3></td>
-</tr>
-</tbody>
-</table>
-<p>Bacon eatsum dolor amet bacon sausage bresaola salami porchetta short ribs andouille cow ribeye rump meatball sirloin ham pancetta pork belly. Sausage hamburger beef ribs sirloin, turducken filet mignon fatback shank biltong cow landjaeger. Drumstick pastrami tail venison cow kevin sirloin picanha porchetta short loin hamburger. Shoulder chicken prosciutto turkey pork belly drumstick doner hamburger. Cow tail alcatra pork loin biltong pancetta. Cow cupim tri-tip pancetta brisket hamburger ham, ball tip kielbasa capicola. Pancetta alcatra capicola pork.</p>
-<table style="width: 100%">
-<tbody>
-  <tr><th><br/></th><th><br/></th></tr>
-  <tr><td><br/></td><td><br/></td></tr>
-  <tr><td><br/></td><td><br/></td></tr>
-</tbody>
-</table>
-<p>Bacon eatsum dolor amet bacon sausage bresaola salami porchetta short ribs andouille cow ribeye rump meatball sirloin ham pancetta pork belly. Sausage hamburger beef ribs sirloin, turducken filet mignon fatback shank biltong cow landjaeger. Drumstick pastrami tail venison cow kevin sirloin picanha porchetta short loin hamburger. Shoulder chicken prosciutto turkey pork belly drumstick doner hamburger. Cow tail alcatra pork loin biltong pancetta. Cow cupim tri-tip pancetta brisket hamburger ham, ball tip kielbasa capicola. Pancetta alcatra capicola pork.</p>
-<ul>
-<li>
-<h1><u>Bacon eatsum</u>&sup1;</h1>
-<ol>
-<li><h3>Krispy Bacon&#8482;</h3></li>
-<li><h3>Bacon Krispies<small>&reg;</small></h3></li>
-</ol>
-</li>
-</ul>
-<p>Bacon eatsum dolor amet bacon sausage bresaola salami porchetta short ribs andouille cow ribeye rump meatball sirloin ham pancetta pork belly. Sausage hamburger beef ribs sirloin, turducken filet mignon fatback shank biltong cow landjaeger. Drumstick pastrami tail venison cow kevin sirloin picanha porchetta short loin hamburger. Shoulder chicken prosciutto turkey pork belly drumstick doner hamburger. Cow tail alcatra pork loin biltong pancetta. Cow cupim tri-tip pancetta brisket hamburger ham, ball tip kielbasa capicola. Pancetta alcatra capicola pork.</p>
-<p><br/></p>
+      </tbody>
+    </table>
+    <p>Bacon eatsum dolor amet bacon sausage bresaola salami porchetta short ribs andouille cow ribeye rump meatball
+      sirloin ham pancetta pork belly. Sausage hamburger beef ribs sirloin, turducken filet mignon fatback shank biltong
+      cow landjaeger. Drumstick pastrami tail venison cow kevin sirloin picanha porchetta short loin hamburger. Shoulder
+      chicken prosciutto turkey pork belly drumstick doner hamburger. Cow tail alcatra pork loin biltong pancetta. Cow
+      cupim tri-tip pancetta brisket hamburger ham, ball tip kielbasa capicola. Pancetta alcatra capicola pork.</p>
+    <table style="width: 100%">
+      <tbody>
+        <tr>
+          <th><br /></th>
+          <th><br /></th>
+        </tr>
+        <tr>
+          <td><br /></td>
+          <td><br /></td>
+        </tr>
+        <tr>
+          <td><br /></td>
+          <td><br /></td>
+        </tr>
+      </tbody>
+    </table>
+    <p>Bacon eatsum dolor amet bacon sausage bresaola salami porchetta short ribs andouille cow ribeye rump meatball
+      sirloin ham pancetta pork belly. Sausage hamburger beef ribs sirloin, turducken filet mignon fatback shank biltong
+      cow landjaeger. Drumstick pastrami tail venison cow kevin sirloin picanha porchetta short loin hamburger. Shoulder
+      chicken prosciutto turkey pork belly drumstick doner hamburger. Cow tail alcatra pork loin biltong pancetta. Cow
+      cupim tri-tip pancetta brisket hamburger ham, ball tip kielbasa capicola. Pancetta alcatra capicola pork.</p>
+    <ul>
+      <li>
+        <h1><u>Bacon eatsum</u>&sup1;</h1>
+        <ol>
+          <li>
+            <h3>Krispy Bacon&#8482;</h3>
+          </li>
+          <li>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </li>
+        </ol>
+      </li>
+    </ul>
+    <p>Bacon eatsum dolor amet bacon sausage bresaola salami porchetta short ribs andouille cow ribeye rump meatball
+      sirloin ham pancetta pork belly. Sausage hamburger beef ribs sirloin, turducken filet mignon fatback shank biltong
+      cow landjaeger. Drumstick pastrami tail venison cow kevin sirloin picanha porchetta short loin hamburger. Shoulder
+      chicken prosciutto turkey pork belly drumstick doner hamburger. Cow tail alcatra pork loin biltong pancetta. Cow
+      cupim tri-tip pancetta brisket hamburger ham, ball tip kielbasa capicola. Pancetta alcatra capicola pork.</p>
+    <p><br /></p>
 
-</div>
-<h1>heading</h1>
-<p>
-One or two
-</p>
-<p>
-<a href="link.test">
-        <!-- <img src='http://google.com/google.jpg' > -->
-      </a>
-</p>
-<p>
-One or two
-</p>
-<p>test</p>
-<p>
-One or two
-</p>
-<p>test</p>
-<p>
-One or two
-</p>
-<p>test</p>
+    <h3>2nd Iteration</h3>
 
-<!-- <div id="toolbar_container"></div> -->
-<div class='tiny-text' style="margin-left: 50px">editor 2</div>
+    <p><a href="http://www.baconipsum.com">Bacon</a> eatsum dolor amet <a href="http://www.baconipsum.com">Bacon</a>
+      sausage bresaola salami porchetta short ribs andouille cow ribeye rump meatball sirloin ham pancetta pork belly.
+      Sausage hamburger beef ribs sirloin, turducken filet mignon fatback shank biltong cow landjaeger. Drumstick
+      pastrami tail venison cow kevin sirloin picanha porchetta short loin hamburger. Shoulder chicken prosciutto turkey
+      pork belly drumstick doner hamburger. Cow tail alcatra pork loin biltong pancetta. Cow cupim tri-tip pancetta
+      brisket hamburger ham, ball tip kielbasa capicola. Pancetta alcatra capicola pork.</p>
+    <blockquote>
+      <p><a href="http://www.baconipsum.com">Bacon</a> eatsum dolor amet <a href="http://www.baconipsum.com">Bacon</a>
+        sausage bresaola salami porchetta short ribs andouille cow ribeye rump meatball sirloin ham pancetta pork belly.
+        Sausage hamburger beef ribs sirloin, turducken filet mignon fatback shank biltong cow landjaeger. Drumstick
+        pastrami tail venison cow kevin sirloin picanha porchetta short loin hamburger. Shoulder chicken prosciutto
+        turkey pork belly drumstick doner hamburger. Cow tail alcatra pork loin biltong pancetta. Cow cupim tri-tip
+        pancetta brisket hamburger ham, ball tip kielbasa capicola. Pancetta alcatra capicola pork.</p>
+    </blockquote>
+    <table style="width: 100%">
+      <tbody>
+        <tr>
+          <th colspan="2">
+            <h1><u><a href="http://www.baconipsum.com">Bacon</a> eatsum</u>&sup1;</h1>
+          </th>
+        </tr>
+        <tr>
+          <td>
+            <h3>Krispy Bacon&#8482;</h3>
+          </td>
+          <td>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <p>Bacon eatsum dolor amet bacon sausage bresaola salami porchetta short ribs andouille cow ribeye rump meatball
+      sirloin ham pancetta pork belly. Sausage hamburger beef ribs sirloin, turducken filet mignon fatback shank biltong
+      cow landjaeger. Drumstick pastrami tail venison cow kevin sirloin picanha porchetta short loin hamburger. Shoulder
+      chicken prosciutto turkey pork belly drumstick doner hamburger. Cow tail alcatra pork loin biltong pancetta. Cow
+      cupim tri-tip pancetta brisket hamburger ham, ball tip kielbasa capicola. Pancetta alcatra capicola pork.</p>
+    <table style="width: 100%">
+      <tbody>
+        <tr>
+          <th><br /></th>
+          <th><br /></th>
+        </tr>
+        <tr>
+          <td><br /></td>
+          <td><br /></td>
+        </tr>
+        <tr>
+          <td><br /></td>
+          <td><br /></td>
+        </tr>
+      </tbody>
+    </table>
+    <p>Bacon eatsum dolor amet bacon sausage bresaola salami porchetta short ribs andouille cow ribeye rump meatball
+      sirloin ham pancetta pork belly. Sausage hamburger beef ribs sirloin, turducken filet mignon fatback shank biltong
+      cow landjaeger. Drumstick pastrami tail venison cow kevin sirloin picanha porchetta short loin hamburger. Shoulder
+      chicken prosciutto turkey pork belly drumstick doner hamburger. Cow tail alcatra pork loin biltong pancetta. Cow
+      cupim tri-tip pancetta brisket hamburger ham, ball tip kielbasa capicola. Pancetta alcatra capicola pork.</p>
+    <ul>
+      <li>
+        <h1><u>Bacon eatsum</u>&sup1;</h1>
+        <ol>
+          <li>
+            <h3>Krispy Bacon&#8482;</h3>
+          </li>
+          <li>
+            <h3>Bacon Krispies<small>&reg;</small></h3>
+          </li>
+        </ol>
+      </li>
+    </ul>
+    <p>Bacon eatsum dolor amet bacon sausage bresaola salami porchetta short ribs andouille cow ribeye rump meatball
+      sirloin ham pancetta pork belly. Sausage hamburger beef ribs sirloin, turducken filet mignon fatback shank biltong
+      cow landjaeger. Drumstick pastrami tail venison cow kevin sirloin picanha porchetta short loin hamburger. Shoulder
+      chicken prosciutto turkey pork belly drumstick doner hamburger. Cow tail alcatra pork loin biltong pancetta. Cow
+      cupim tri-tip pancetta brisket hamburger ham, ball tip kielbasa capicola. Pancetta alcatra capicola pork.</p>
+    <p><br /></p>
 
-<script src="../../../../../../js/tinymce/tinymce.js"></script>
-<script src="../../../../../../scratch/demos/themes/silver/demo.js"></script>
-<script>
-  demos.PlayDemo();
-</script>
+  </div>
+  <h1>heading</h1>
+  <p>
+    One or two
+  </p>
+  <p>
+    <a href="link.test">
+      <!-- <img src='http://google.com/google.jpg' > -->
+    </a>
+  </p>
+  <p>
+    One or two
+  </p>
+  <p>test</p>
+  <p>
+    One or two
+  </p>
+  <p>test</p>
+  <p>
+    One or two
+  </p>
+  <p>test</p>
+
+  <!-- <div id="toolbar_container"></div> -->
+  <div class='tiny-text' style="margin-left: 50px">editor 2</div>
+
+  <script src="../../../../../../js/tinymce/tinymce.js"></script>
+  <script src="../../../../../../scratch/demos/themes/silver/demo.js"></script>
+  <script>
+    demos.PlayDemo();
+  </script>
 </body>
+
 </html>

--- a/notes/context-toolbar-changes.md
+++ b/notes/context-toolbar-changes.md
@@ -1,0 +1,73 @@
+Changes made
+
+
+src/themes/silver/main/ts/ContextToolbar.ts
+
+* introduced two new layout types for docking.
+* switched on the order of the docking layouts depending on the current class on contextbar
+* had to thread contextbar through to the desktop layouts (would rather handle in alloy)
+* logging
+* stopping closing on focus lost for easier debugging
+
+alloy/src/main/ts/ephox/alloy/positioning/mode/ContentAnchorCommon.ts
+
+* stopped capRect doing any capping.
+
+alloy/src/main/ts/ephox/alloy/positioning/mode/NodeAnchor.ts
+
+* logging and inline comments
+
+alloy/src/main/ts/ephox/alloy/positioning/view/Bounder.ts
+
+* docked-override for "fitting"
+* logging
+
+
+
+Problems
+
+- upAvailable sets maxHeight, which puts bubble/caret in wrong position while not quite capped at the edge.
+- code is hacked
+- all the guantlets aren't really understood.
+
+
+
+So the current approach: drawing a context toolbar for a table.
+
+anchor: NodeAnchor linking to node: table.
+bounds: editor content area for classic mode
+
+
+
+
+
+```
+Positioning.positionWithinBounds
+
+ - withinBounds: seems to be from src/themes/silver/main/ts/ui/context/ContextToolbarBounds.getContextToolbarBounds. It does a lot of calculations to identify the content area of the editor, based on the editor configuration (inline, fixed toolbar etc.)
+
+This means that the context toolbar will be in the editor area when it has been capped to bounds.
+
+This bounds calculation is passed through many layers until eventually it ends up as the parameter: `getBounds` in `SimpleLayout.simple`. It is then converted to a viewport origin and passed through to `Callouts.layout`, which passed it through to `Bounder.attempts`.
+
+Bounder.attempts is going to try each layout in order until it finds one that fits perfectly. If it doesn't find one that fits perfectly, it will keep going, remembering the "closest fitting" layout so far. Each one is tried through `attempt`, which is passed `bounds`.
+
+`bounds` is then `adjusted by `LayoutBounds.adjustBounds`, which *appears* to be trying to ensure that the bounds are limited by the anchorBox (which in this case is the table node). The restrictions are defined at the layout level.
+
+Meanwhile, another capping occurs. The `placement` function defined by a `NodeAnchor` (which is what table context menu uses), would ensure that the anchor box did not go before (0, 0). This `placement` is used to get the `Anchoring` information for the SimpleLayout. So by the time it gets there, the anchorBox has been capped.
+
+So Anchoring does this:
+
+anchorBox (which is capped now to not be before 0, 0) - but I don't think it should be.
+bubble - the bubbles for all directions
+overrides
+ - maxHeightFunction
+ - maxWidthFunction
+layouts: list of layouts. The LTR and RTL is already done by the time we make this.
+placer: a custom function to replace the one in Positioning. What uses this? We may never actually use it any more.
+
+And the thing that is responsible for that is the type of anchor.
+
+---
+
+


### PR DESCRIPTION
Sort of the "marked as duplicate task": https://ephocks.atlassian.net/browse/TINY-7191 

So this is an attempt to get part of what Fredrik was wanting. Feel free to ignore all of it ... it's likely the wrong way to go about it. The basic idea is:

* add some new layout types that just use the anchor box (which is the table). They appear at the top or the bottom
* stop capping the anchor box
* get the "docking" behaviour by using the limitX and limitY already in Bounder

The animation will probably be OK for top -> top or bottom -> bottom, but it won't work for top -> bottom etc. There is a comment explaining what might resolve the problem.

There is also an issue with carets and maxWidth / maxHeight calculations. Almost entirely uninvestigated.

